### PR TITLE
[#3] 로그인 및 로그아웃 - getUserByEmail의 Optional 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'junit:junit:4.13.1' // junit 5는 안될까요 ?
+	testImplementation 'junit:junit:4.13.1'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.0' // mapper unit test
 }

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'junit:junit:4.13.1'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.0' // mapper unit test
 }

--- a/src/main/java/com/smart/user/controller/UserController.java
+++ b/src/main/java/com/smart/user/controller/UserController.java
@@ -1,14 +1,14 @@
 package com.smart.user.controller;
 
 import com.smart.user.controller.dto.UserDto;
+import com.smart.user.controller.dto.UserDto.UserInfo;
 import com.smart.user.service.UserService;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.Optional;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,7 +29,7 @@ public class UserController {
   }
 
   @GetMapping("/{email}/exist")
-  public UserDto.Response getUser(@PathVariable("email") String email) {
+  public Optional<UserInfo> getUser(@PathVariable("email") String email) {
     return userService.getUserByEmail(email);
   }
 

--- a/src/main/java/com/smart/user/controller/UserController.java
+++ b/src/main/java/com/smart/user/controller/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
   }
 
   @GetMapping("/{email}/exist")
-  public Optional<UserInfo> getUser(@PathVariable("email") String email) {
+  public UserInfo getUser(@PathVariable("email") String email) {
     return userService.getUserByEmail(email);
   }
 

--- a/src/main/java/com/smart/user/controller/UserController.java
+++ b/src/main/java/com/smart/user/controller/UserController.java
@@ -1,11 +1,11 @@
 package com.smart.user.controller;
 
+import com.smart.global.error.NotFoundUserException;
 import com.smart.user.controller.dto.UserDto;
 import com.smart.user.controller.dto.UserDto.UserInfo;
 import com.smart.user.service.UserService;
 import jakarta.validation.Valid;
 import java.net.URI;
-import java.util.Optional;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -29,8 +29,13 @@ public class UserController {
   }
 
   @GetMapping("/{email}/exist")
-  public UserInfo getUser(@PathVariable("email") String email) {
-    return userService.getUserByEmail(email);
+  public ResponseEntity<UserInfo> getUser(@PathVariable("email") String email) {
+    try {
+      UserInfo userInfo = userService.getUserByEmail(email);
+      return ResponseEntity.ok(userInfo);
+    } catch (NotFoundUserException e) {
+      return ResponseEntity.notFound().build();
+    }
   }
 
   @PostMapping("/join")

--- a/src/main/java/com/smart/user/controller/dto/UserDto.java
+++ b/src/main/java/com/smart/user/controller/dto/UserDto.java
@@ -20,7 +20,7 @@ public class UserDto {
   @NoArgsConstructor(access = AccessLevel.PROTECTED)
   @AllArgsConstructor
   @Builder
-  public static class Response {
+  public static class UserInfo {
 
     @NotBlank
     private Long userId;
@@ -47,8 +47,8 @@ public class UserDto {
 
     private String role;
 
-    static public Response toResponse(User user) {
-      return Response.builder()
+    static public UserInfo from(User user) {
+      return UserInfo.builder()
           .userId(user.getUserId())
           .name(user.getName())
           .email(user.getEmail())

--- a/src/main/java/com/smart/user/dao/UserDao.java
+++ b/src/main/java/com/smart/user/dao/UserDao.java
@@ -9,7 +9,7 @@ import org.apache.ibatis.annotations.Param;
 @Mapper
 public interface UserDao {
 
-  User getUserByEmail(String email);
+  Optional<User> getUserByEmail(String email);
 
   void deleteUserByEmail(String email);
 

--- a/src/main/java/com/smart/user/domain/CustomUserDetails.java
+++ b/src/main/java/com/smart/user/domain/CustomUserDetails.java
@@ -61,7 +61,7 @@ public class CustomUserDetails implements UserDetails {
 
   @Override
   public String getUsername() {
-    return name;
+    return email;
   }
 
   @Override

--- a/src/main/java/com/smart/user/service/UserSecurityService.java
+++ b/src/main/java/com/smart/user/service/UserSecurityService.java
@@ -1,46 +1,44 @@
 package com.smart.user.service;
 
 import com.smart.global.error.NotFoundUserException;
-import com.smart.user.dao.UserDao;
+import com.smart.user.controller.dto.UserDto.UserInfo;
 import com.smart.user.domain.CustomUserDetails;
 import java.util.Arrays;
 import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserSecurityService implements UserDetailsService {
-  private final UserDao userDao;
+  private final UserService userService;
   private final PasswordEncoder passwordEncoder;
 
   @Override
-  public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-    com.smart.user.domain.User user = userDao.getUserByEmail(email);
-    if (user == null) {
-      throw new NotFoundUserException();
-    }
+  public UserDetails loadUserByUsername(String email) {
+    UserInfo userInfo = userService.getUserByEmail(email)
+        .orElseThrow(() -> new NotFoundUserException());
 
-    return buildUserDetails(user);
+    return buildUserDetails(userInfo);
   }
 
-  private CustomUserDetails buildUserDetails(com.smart.user.domain.User user) {
+
+
+  private CustomUserDetails buildUserDetails(UserInfo userInfo) {
     Collection<? extends GrantedAuthority> authorities = Arrays.asList(
-        new SimpleGrantedAuthority(user.getRole()));
+        new SimpleGrantedAuthority(userInfo.getRole()));
 
     CustomUserDetails userDetails = new CustomUserDetails();
-    userDetails.setUserId(user.getUserId());
-    userDetails.setName(user.getName());
-    userDetails.setNickname(user.getNickname());
-    userDetails.setEmail(user.getEmail());
-    userDetails.setPassword(passwordEncoder.encode(user.getPassword()));
+    userDetails.setUserId(userInfo.getUserId());
+    userDetails.setName(userInfo.getName());
+    userDetails.setNickname(userInfo.getNickname());
+    userDetails.setEmail(userInfo.getEmail());
+    userDetails.setPassword(passwordEncoder.encode(userInfo.getPassword()));
     userDetails.setAuthorities(authorities);
 
     return userDetails;

--- a/src/main/java/com/smart/user/service/UserSecurityService.java
+++ b/src/main/java/com/smart/user/service/UserSecurityService.java
@@ -1,6 +1,5 @@
 package com.smart.user.service;
 
-import com.smart.global.error.NotFoundUserException;
 import com.smart.user.controller.dto.UserDto.UserInfo;
 import com.smart.user.domain.CustomUserDetails;
 import java.util.Arrays;
@@ -25,8 +24,6 @@ public class UserSecurityService implements UserDetailsService {
 
     return buildUserDetails(userInfo);
   }
-
-
 
   private CustomUserDetails buildUserDetails(UserInfo userInfo) {
     Collection<? extends GrantedAuthority> authorities = Arrays.asList(

--- a/src/main/java/com/smart/user/service/UserSecurityService.java
+++ b/src/main/java/com/smart/user/service/UserSecurityService.java
@@ -21,8 +21,7 @@ public class UserSecurityService implements UserDetailsService {
 
   @Override
   public UserDetails loadUserByUsername(String email) {
-    UserInfo userInfo = userService.getUserByEmail(email)
-        .orElseThrow(() -> new NotFoundUserException());
+    UserInfo userInfo = userService.getUserByEmail(email);
 
     return buildUserDetails(userInfo);
   }

--- a/src/main/java/com/smart/user/service/UserService.java
+++ b/src/main/java/com/smart/user/service/UserService.java
@@ -12,5 +12,4 @@ public interface UserService {
 
   Optional<UserInfo> getUserByEmail(String email);
 
-
 }

--- a/src/main/java/com/smart/user/service/UserService.java
+++ b/src/main/java/com/smart/user/service/UserService.java
@@ -10,6 +10,6 @@ public interface UserService {
 
   void verifyAuthCode(String email, String authCode);
 
-  Optional<UserInfo> getUserByEmail(String email);
+  UserInfo getUserByEmail(String email);
 
 }

--- a/src/main/java/com/smart/user/service/UserService.java
+++ b/src/main/java/com/smart/user/service/UserService.java
@@ -1,6 +1,8 @@
 package com.smart.user.service;
 
 import com.smart.user.controller.dto.UserDto;
+import com.smart.user.controller.dto.UserDto.UserInfo;
+import java.util.Optional;
 
 public interface UserService {
 
@@ -8,5 +10,7 @@ public interface UserService {
 
   void verifyAuthCode(String email, String authCode);
 
-  UserDto.Response getUserByEmail(String email);
+  Optional<UserInfo> getUserByEmail(String email);
+
+
 }

--- a/src/main/java/com/smart/user/service/implement/UserServiceImpl.java
+++ b/src/main/java/com/smart/user/service/implement/UserServiceImpl.java
@@ -70,10 +70,8 @@ public class UserServiceImpl implements UserService {
   }
   @Override
   public UserInfo getUserByEmail(String email) {
-    User user = userDao.getUserByEmail(email);
-    if (user == null) {
-      throw new NotFoundUserException();
-    }
+    Optional<User> optionalUser = userDao.getUserByEmail(email);
+    User user = optionalUser.orElseThrow(NotFoundUserException::new);
     return UserDto.UserInfo.from(user);
   }
 }

--- a/src/main/java/com/smart/user/service/implement/UserServiceImpl.java
+++ b/src/main/java/com/smart/user/service/implement/UserServiceImpl.java
@@ -70,8 +70,8 @@ public class UserServiceImpl implements UserService {
   }
   @Override
   public UserInfo getUserByEmail(String email) {
-    Optional<User> optionalUser = userDao.getUserByEmail(email);
-    User user = optionalUser.orElseThrow(NotFoundUserException::new);
+    User user = userDao.getUserByEmail(email)
+        .orElseThrow(NotFoundUserException::new);
     return UserDto.UserInfo.from(user);
   }
 }

--- a/src/main/java/com/smart/user/service/implement/UserServiceImpl.java
+++ b/src/main/java/com/smart/user/service/implement/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.smart.user.service.implement;
 import com.smart.global.error.DuplicatedUserEmailException;
 import com.smart.global.error.DuplicatedUserNicknameException;
 import com.smart.global.error.IllegalAuthCodeException;
+import com.smart.global.error.NotFoundUserException;
 import com.smart.mail.event.MailAuthEvent;
 import com.smart.user.controller.dto.UserDto;
 import com.smart.user.controller.dto.UserDto.UserInfo;
@@ -68,8 +69,11 @@ public class UserServiceImpl implements UserService {
     }
   }
   @Override
-  public Optional<UserInfo> getUserByEmail(String email) {
+  public UserInfo getUserByEmail(String email) {
     User user = userDao.getUserByEmail(email);
-    return Optional.ofNullable(UserDto.UserInfo.from(user));
+    if (user == null) {
+      throw new NotFoundUserException();
+    }
+    return UserDto.UserInfo.from(user);
   }
 }

--- a/src/main/java/com/smart/user/service/implement/UserServiceImpl.java
+++ b/src/main/java/com/smart/user/service/implement/UserServiceImpl.java
@@ -3,14 +3,15 @@ package com.smart.user.service.implement;
 import com.smart.global.error.DuplicatedUserEmailException;
 import com.smart.global.error.DuplicatedUserNicknameException;
 import com.smart.global.error.IllegalAuthCodeException;
-import com.smart.global.error.NotFoundUserException;
 import com.smart.mail.event.MailAuthEvent;
 import com.smart.user.controller.dto.UserDto;
+import com.smart.user.controller.dto.UserDto.UserInfo;
 import com.smart.user.dao.UserDao;
 import com.smart.user.domain.Status;
 import com.smart.user.domain.User;
 import com.smart.user.service.UserService;
 import jakarta.servlet.http.HttpSession;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -66,13 +67,9 @@ public class UserServiceImpl implements UserService {
       throw new IllegalAuthCodeException();
     }
   }
-
   @Override
-  public UserDto.Response getUserByEmail(String email) {
+  public Optional<UserInfo> getUserByEmail(String email) {
     User user = userDao.getUserByEmail(email);
-    if (user == null) {
-      throw new NotFoundUserException();
-    }
-    return UserDto.Response.toResponse(user);
+    return Optional.ofNullable(UserDto.UserInfo.from(user));
   }
 }

--- a/src/test/java/com/smart/user/controller/SecurityIntegrationTest.java
+++ b/src/test/java/com/smart/user/controller/SecurityIntegrationTest.java
@@ -3,7 +3,6 @@ package com.smart.user.controller;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/com/smart/user/dao/UserDaoTest.java
+++ b/src/test/java/com/smart/user/dao/UserDaoTest.java
@@ -3,6 +3,7 @@ package com.smart.user.dao;
 import com.smart.user.controller.dto.UserDto.JoinRequest;
 import com.smart.user.domain.Status;
 import com.smart.user.domain.User;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,8 +48,8 @@ class UserDaoTest {
   public void 유저회원가입() {
     userDao.joinUser(user);
 
-    User retUser = userDao.getUserByEmail(user.getEmail());
-    Assertions.assertEquals(user.getUserId(), retUser.getUserId());
+    Optional<User> retUser = userDao.getUserByEmail(user.getEmail());
+    Assertions.assertEquals(user.getUserId(), retUser.get().getUserId());
   }
 
   @Test
@@ -57,9 +58,10 @@ class UserDaoTest {
 
     userDao.updateUserStatus(user.getEmail(), Status.NORMAL);
 
-    User retUser = userDao.getUserByEmail(user.getEmail());
-    Assertions.assertEquals(Status.NORMAL, retUser.getUserStatus());
+    Optional<User> retUser = userDao.getUserByEmail(user.getEmail());
+    Assertions.assertEquals(Status.NORMAL, retUser.get().getUserStatus());
   }
+
 
   @Test
   public void 중복이메일체크() {

--- a/src/test/java/com/smart/user/service/UserSecurityServiceTest.java
+++ b/src/test/java/com/smart/user/service/UserSecurityServiceTest.java
@@ -1,26 +1,15 @@
 package com.smart.user.service;
 
-import com.smart.global.error.NotFoundUserException;
-import com.smart.user.controller.dto.UserDto;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
 import com.smart.user.controller.dto.UserDto.UserInfo;
-import com.smart.user.dao.UserDao;
-import java.util.Optional;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class UserSecurityServiceTest {
   @InjectMocks

--- a/src/test/java/com/smart/user/service/UserSecurityServiceTest.java
+++ b/src/test/java/com/smart/user/service/UserSecurityServiceTest.java
@@ -1,38 +1,55 @@
 package com.smart.user.service;
 
 import com.smart.global.error.NotFoundUserException;
+import com.smart.user.controller.dto.UserDto;
+import com.smart.user.controller.dto.UserDto.UserInfo;
 import com.smart.user.dao.UserDao;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class UserSecurityServiceTest {
+  @InjectMocks
   private UserSecurityService userSecurityService;
+  @Mock
+  private PasswordEncoder passwordEncoder;
   @Mock
   private UserService userService;
 
-  @BeforeEach
-  public void setUp() {
-    userSecurityService = new UserSecurityService(userService, null);
-  }
 
   @Test
-  public void testLoadUserByUsernameWithNotFoundUserException() {
-    String email = "invalidEmail@example.com";
-    when(userService.getUserByEmail(email)).thenReturn(Optional.empty());
+  public void loadUserByUsername() {
+    //given : 이메일이 주어지고
+    var email = "test@gmail.com";
+    var userInfo= UserInfo.builder()
+        .userId(1L)
+        .name("test")
+        .email(email)
+        .password("1234")
+        .role("USER")
+        .build();
 
-    Assertions.assertThrows(
-        NotFoundUserException.class,
-        () -> userSecurityService.loadUserByUsername(email)
-    );
+    //when : 사용자를 조회했을때
+    when(userService.getUserByEmail(email)).thenReturn(userInfo);
+    when(passwordEncoder.encode(userInfo.getPassword())).thenReturn(userInfo.getPassword());
+    var userDetails = userSecurityService.loadUserByUsername(email);
+
+    //then : 사용자 정보를 확인할 수 있다.
+    assertEquals(email,userDetails.getUsername());
   }
 }
 

--- a/src/test/java/com/smart/user/service/UserSecurityServiceTest.java
+++ b/src/test/java/com/smart/user/service/UserSecurityServiceTest.java
@@ -25,7 +25,7 @@ public class UserSecurityServiceTest {
   }
 
   @Test
-  public void testLoadUserByUsernameWithNotFou성ndUserException() {
+  public void testLoadUserByUsernameWithNotFoundUserException() {
     String email = "invalidEmail@example.com";
     when(userService.getUserByEmail(email)).thenReturn(Optional.empty());
 

--- a/src/test/java/com/smart/user/service/UserSecurityServiceTest.java
+++ b/src/test/java/com/smart/user/service/UserSecurityServiceTest.java
@@ -2,33 +2,37 @@ package com.smart.user.service;
 
 import com.smart.global.error.NotFoundUserException;
 import com.smart.user.dao.UserDao;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
-
+@ExtendWith(MockitoExtension.class)
 public class UserSecurityServiceTest {
   private UserSecurityService userSecurityService;
-
   @Mock
-  private UserDao userDao;
+  private UserService userService;
 
   @BeforeEach
   public void setUp() {
-    MockitoAnnotations.openMocks(this);
-    userSecurityService = new UserSecurityService(userDao, null);
+    userSecurityService = new UserSecurityService(userService, null);
   }
 
   @Test
-  public void testLoadUserByUsernameWithNotFoundUserException() {
-    // given
+  public void testLoadUserByUsernameWithNotFou성ndUserException() {
     String email = "invalidEmail@example.com";
-    when(userDao.getUserByEmail(email)).thenReturn(null);
+    when(userService.getUserByEmail(email)).thenReturn(Optional.empty());
 
-    // when, then
-    assertThrows(NotFoundUserException.class, () -> userSecurityService.loadUserByUsername(email));
+    Assertions.assertThrows(
+        NotFoundUserException.class,
+        () -> userSecurityService.loadUserByUsername(email)
+    );
   }
 }
+

--- a/src/test/java/com/smart/user/service/implement/UserServiceImplTest.java
+++ b/src/test/java/com/smart/user/service/implement/UserServiceImplTest.java
@@ -1,6 +1,5 @@
 package com.smart.user.service.implement;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -18,6 +17,7 @@ import com.smart.user.dao.UserDao;
 import com.smart.user.domain.Status;
 import com.smart.user.domain.User;
 import jakarta.servlet.http.HttpSession;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +30,7 @@ import org.springframework.mock.web.MockHttpSession;
 
 /**
  * Mockito ArgumentCaptor : ArgumentCaptor를 사용하여 메서드에 전달된 파라미터를 캡처하여 테스트 할 수 있다.
- * Mockito Verify :메서드 호출, 호출 횟수, interaction 등을 검증할 수 있다.
+ * Mockito Verify : 메서드 호출, 호출 횟수, interaction 등을 검증할 수 있다.
  */
 @ExtendWith(MockitoExtension.class)
 class UserServiceImplTest {
@@ -85,7 +85,7 @@ class UserServiceImplTest {
     userService.join(joinRequest);
 
     verify(eventPublisher).publishEvent(any(MailAuthEvent.class));
-    assertEquals(joinRequest.getEmail(), mailEventCaptor.getValue().getEmail());
+    Assertions.assertEquals(joinRequest.getEmail(), mailEventCaptor.getValue().getEmail());
   }
 
   @DisplayName("회원가입을 성공하여 인증코드를 세션에 저장한다.")
@@ -105,7 +105,7 @@ class UserServiceImplTest {
     userService.join(joinRequest);
 
     verify(userDao).joinUser(any(User.class));
-    assertEquals(joinRequest.getEmail(), userCaptor.getValue().getEmail());
+    Assertions.assertEquals(joinRequest.getEmail(), userCaptor.getValue().getEmail());
   }
 
   @DisplayName("중복닉네임으로 회원가입을 실패한다.")
@@ -151,18 +151,18 @@ class UserServiceImplTest {
   @DisplayName("가입된 이메일로 유저찾기를 성공한다.")
   @Test
   public void 유저찾기성공() {
-    when(userDao.getUserByEmail("test@email")).thenReturn(user);
+    when(userDao.getUserByEmail("test@email")).thenReturn(Optional.of(user));
 
-    UserInfo result = userService.getUserByEmail("test@email");
+    UserInfo userInfo = userService.getUserByEmail("test@email");
 
     verify(userDao).getUserByEmail("test@email");
-    assertEquals(user.getEmail(), result.getEmail());
+    Assertions.assertEquals("test@email", userInfo.getEmail());
   }
 
   @DisplayName("가입되지 않은 이메일로 유저찾기를 실패한다.")
   @Test
   public void 유저찾기실패() {
-    when(userDao.getUserByEmail("test@email")).thenReturn(null);
+    when(userDao.getUserByEmail("test@email")).thenReturn(Optional.empty());
 
     Assertions
         .assertThrows(NotFoundUserException.class, () -> userService.getUserByEmail("test@email"));

--- a/src/test/java/com/smart/user/service/implement/UserServiceImplTest.java
+++ b/src/test/java/com/smart/user/service/implement/UserServiceImplTest.java
@@ -155,10 +155,10 @@ class UserServiceImplTest {
   public void 유저찾기성공() {
     when(userDao.getUserByEmail("test@email")).thenReturn(user);
 
-    Optional<UserInfo> result = userService.getUserByEmail("test@email");
+    UserInfo result = userService.getUserByEmail("test@email");
 
     verify(userDao).getUserByEmail("test@email");
-    assertEquals(user.getEmail(), result.get().getEmail());
+    assertEquals(user.getEmail(), result.getEmail());
   }
 
   @DisplayName("가입되지 않은 이메일로 유저찾기를 실패한다.")

--- a/src/test/java/com/smart/user/service/implement/UserServiceImplTest.java
+++ b/src/test/java/com/smart/user/service/implement/UserServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.smart.user.service.implement;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -11,12 +12,14 @@ import com.smart.global.error.DuplicatedUserNicknameException;
 import com.smart.global.error.IllegalAuthCodeException;
 import com.smart.global.error.NotFoundUserException;
 import com.smart.mail.event.MailAuthEvent;
+import com.smart.user.controller.dto.UserDto;
 import com.smart.user.controller.dto.UserDto.JoinRequest;
-import com.smart.user.controller.dto.UserDto.Response;
+import com.smart.user.controller.dto.UserDto.UserInfo;
 import com.smart.user.dao.UserDao;
 import com.smart.user.domain.Status;
 import com.smart.user.domain.User;
 import jakarta.servlet.http.HttpSession;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +32,7 @@ import org.springframework.mock.web.MockHttpSession;
 
 /**
  * Mockito ArgumentCaptor : ArgumentCaptor를 사용하여 메서드에 전달된 파라미터를 캡처하여 테스트 할 수 있다.
- * Mockito Verify : 메서드 호출, 호출 횟수, interaction 등을 검증할 수 있다.
+ * Mockito Verify :메서드 호출, 호출 횟수, interaction 등을 검증할 수 있다.
  */
 @ExtendWith(MockitoExtension.class)
 class UserServiceImplTest {
@@ -152,10 +155,10 @@ class UserServiceImplTest {
   public void 유저찾기성공() {
     when(userDao.getUserByEmail("test@email")).thenReturn(user);
 
-    Response response = userService.getUserByEmail("test@email");
+    Optional<UserInfo> result = userService.getUserByEmail("test@email");
 
     verify(userDao).getUserByEmail("test@email");
-    Assertions.assertEquals("test@email", response.getEmail());
+    assertEquals(user.getEmail(), result.get().getEmail());
   }
 
   @DisplayName("가입되지 않은 이메일로 유저찾기를 실패한다.")

--- a/src/test/java/com/smart/user/service/implement/UserServiceImplTest.java
+++ b/src/test/java/com/smart/user/service/implement/UserServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.smart.user.service.implement;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -12,14 +12,12 @@ import com.smart.global.error.DuplicatedUserNicknameException;
 import com.smart.global.error.IllegalAuthCodeException;
 import com.smart.global.error.NotFoundUserException;
 import com.smart.mail.event.MailAuthEvent;
-import com.smart.user.controller.dto.UserDto;
 import com.smart.user.controller.dto.UserDto.JoinRequest;
 import com.smart.user.controller.dto.UserDto.UserInfo;
 import com.smart.user.dao.UserDao;
 import com.smart.user.domain.Status;
 import com.smart.user.domain.User;
 import jakarta.servlet.http.HttpSession;
-import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -87,7 +85,7 @@ class UserServiceImplTest {
     userService.join(joinRequest);
 
     verify(eventPublisher).publishEvent(any(MailAuthEvent.class));
-    Assertions.assertEquals(joinRequest.getEmail(), mailEventCaptor.getValue().getEmail());
+    assertEquals(joinRequest.getEmail(), mailEventCaptor.getValue().getEmail());
   }
 
   @DisplayName("회원가입을 성공하여 인증코드를 세션에 저장한다.")
@@ -107,7 +105,7 @@ class UserServiceImplTest {
     userService.join(joinRequest);
 
     verify(userDao).joinUser(any(User.class));
-    Assertions.assertEquals(joinRequest.getEmail(), userCaptor.getValue().getEmail());
+    assertEquals(joinRequest.getEmail(), userCaptor.getValue().getEmail());
   }
 
   @DisplayName("중복닉네임으로 회원가입을 실패한다.")

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -9,7 +9,7 @@ mybatis.mapper-locations=classpath:mapper/*.xml
 mybatis.configuration.map-underscore-to-camel-case=true
 
 #mail 설정
-spring.mail.host=smtp.gmail.com6
+spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.starttls.required=true


### PR DESCRIPTION
## 개요
유저의 이메일을 통해 유저를 조회하는 메소드 타입을 Optional 변경하였습니다.
userDao로부터 가져오는 User객체가 Null인경우 Optional 빈객체를 반환하도록 변경했습니다. 

## 작업사항
- UserController : 리턴타입 변경(UserDto.Response -> Optional<UserInfo>)
- Response : 이너클래스명 변경 (Response-> UserInfo)
- UserSecurityService : Optional 로직으로 변경 
- UserService : 리턴타입 변경(UserDto.Response -> Optional<UserInfo>)
- UserServiceImpl : 리턴타입 변경(UserDto.Response -> Optional<UserInfo>)
- UserSecurityServiceTest : 유효하지않는 유저정보 Optional.empty()리턴
- UserServiceImplTest : 유저정보 타입 Optional<UserInfo> 처리
- SecurityIntegrationTest 테스트추가

## 변경로직
- 유저 정보를 반환하는 메소드의 리턴타입 UserDto.Response을 Optional<UserInfo>로 변경하였습니다.
- userService에서 조회한 유저정보가 없으면 빈 optional 반환되도록 변경하고 UserSecurityService에서 빈 옵셔널이 반환되면 NotFoundUserException이 발생하도록 변경했습니다.
- UserDao의 이너클래스 Reponse 클래스를 UserInfo으로 변경하였습니다.
- SecurityIntegrationTest 추가 작성하여 스프링 시큐리티의 로그인 인증 과정을 검증하는 테스트를 작성했습니다.
